### PR TITLE
exclude the home page

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@
 // @supportURL         https://github.com/kghost/bilibili-area-limit
 // @author             zealot0630
 // @include            https://www.bilibili.com/*
+// @include            https://www.bilibili.com/
 // @run-at document-start
 // @description Bilibili 港澳台, 解除区域限制
 // ==/UserScript==

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@
 // @supportURL         https://github.com/kghost/bilibili-area-limit
 // @author             zealot0630
 // @include            https://www.bilibili.com/*
-// @include            https://www.bilibili.com/
+// @exclude            https://www.bilibili.com/
 // @run-at document-start
 // @description Bilibili 港澳台, 解除区域限制
 // ==/UserScript==


### PR DESCRIPTION
## 现有问题
在我的电脑（win10）上，如果直接使用现有脚本，会导致首页的**番剧**和**国创**两个模块看不到任何内容，显示为“今天没有番剧更新”。

## 修改策略
由于该脚本对首页其实并没有什么作用，因此可以直接exclude掉B站首页。